### PR TITLE
feat: sync skill with beautiful-mermaid 1.1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A Mermaid diagram rendering skill for AI, supporting both SVG and ASCII output f
 
 - 📊 **Multi-format Support**: SVG and ASCII rendering export
 - 🎨 **Rich Themes**: 15 built-in themes for different scenarios
-- 📈 **Full Diagram Support**: Flowchart, Sequence, State, Class, ER and more
+- 📈 **Six Diagram Types**: Flowchart, Sequence, State, Class, ER, and XY charts
 - ⚡ **High Performance**: Batch parallel rendering
 - 📚 **Ready to Use**: Complete templates and detailed documentation
 
@@ -32,8 +32,8 @@ A Mermaid diagram rendering skill for AI, supporting both SVG and ASCII output f
 | :--- | :--- | :--- |
 | zinc-light | zinc-dark | nord |
 | tokyo-night-light | tokyo-night | nord-light |
-| cappuccin-latte | tokyo-night-storm | dracula |
-| github-light | cappuccin-mocha | one-dark |
+| catppuccin-latte | tokyo-night-storm | dracula |
+| github-light | catppuccin-mocha | one-dark |
 | solarized-light | github-dark | |
 | | solarized-dark | |
 
@@ -88,12 +88,15 @@ node scripts/batch.mjs \
 
 ## 📂 Examples
 
-Check the 5 template files in `assets/example_diagrams/`:
+Check the 6 template files in `assets/example_diagrams/`:
 - `flowchart.mmd` - Flowchart
 - `sequence.mmd` - Sequence Diagram
 - `state.mmd` - State Diagram
 - `class.mmd` - Class Diagram
 - `er.mmd` - ER Diagram
+- `xychart.mmd` - XY Chart (bar and line)
+
+The renderer also supports CJK state names, multiline labels, `linkStyle`, configurable ELK layout spacing, interactive XY chart tooltips, and ANSI-colored terminal output.
 
 ## 📚 Documentation
 See [SKILL.md](SKILL.md) for detailed usage guide.

--- a/README_CN.md
+++ b/README_CN.md
@@ -23,7 +23,7 @@
 
 - 📊 **多格式支持**：支持 SVG 和 ASCII 渲染导出
 - 🎨 **丰富主题**：内置 15 种精美主题，满足不同场景需求
-- 📈 **全图表支持**：支持 Flowchart, Sequence, State, Class, ER 等 5 种常用图表
+- 📈 **六种图表类型**：支持 Flowchart、Sequence、State、Class、ER 和 XY Chart
 - ⚡ **高效渲染**：支持批量并行渲染，速度飞快
 - 📚 **开箱即用**：提供完整的模板和详细文档
 
@@ -32,8 +32,8 @@
 | :--- | :--- | :--- |
 | zinc-light | zinc-dark | nord |
 | tokyo-night-light | tokyo-night | nord-light |
-| cappuccin-latte | tokyo-night-storm | dracula |
-| github-light | cappuccin-mocha | one-dark |
+| catppuccin-latte | tokyo-night-storm | dracula |
+| github-light | catppuccin-mocha | one-dark |
 | solarized-light | github-dark | |
 | | solarized-dark | |
 
@@ -88,12 +88,15 @@ node scripts/batch.mjs \
 
 ## 📂 使用示例
 
-查看 `assets/example_diagrams/` 目录下的 5 个模板文件，快速上手：
+查看 `assets/example_diagrams/` 目录下的 6 个模板文件，快速上手：
 - `flowchart.mmd` - 流程图
 - `sequence.mmd` - 时序图
 - `state.mmd` - 状态图
 - `class.mmd` - 类图
 - `er.mmd` - ER 图
+- `xychart.mmd` - XY 图（柱状图与折线图）
+
+渲染器同时支持中日韩状态名称、多行标签、`linkStyle`、可配置的 ELK 布局间距、XY 图交互提示，以及带 ANSI 颜色的终端输出。
 
 ## 📚 完整文档
 详细使用指南请参阅 [SKILL.md](SKILL.md)

--- a/SKILL.md
+++ b/SKILL.md
@@ -2,15 +2,15 @@
 name: pretty-mermaid
 description: |
   Render beautiful Mermaid diagrams as SVG or ASCII art using the beautiful-mermaid library.
-  Supports 15+ themes, 5 diagram types (flowchart, sequence, state, class, ER), and ultra-fast rendering.
+  Supports 15 themes, 6 diagram types (flowchart, sequence, state, class, ER, XY charts), and ultra-fast rendering.
 
   Use this skill when:
   1. User asks to "render a mermaid diagram" or provides .mmd files
-  2. User requests "create a flowchart/sequence diagram/state diagram"
+  2. User requests "create a flowchart/sequence/state/class/ER/XY chart"
   3. User wants to "apply a theme" or "beautify a diagram"
   4. User needs to "batch process multiple diagrams"
   5. User mentions "ASCII diagram" or "terminal-friendly diagram"
-  6. User wants to visualize architecture, workflows, or data models
+  6. User wants to visualize architecture, workflows, data models, or chart data
 ---
 
 # Pretty Mermaid
@@ -51,7 +51,8 @@ node scripts/batch.mjs \
 node scripts/render.mjs \
   --input diagram.mmd \
   --format ascii \
-  --use-ascii
+  --use-ascii \
+  --color-mode none
 ```
 
 ---
@@ -117,6 +118,7 @@ When user provides a `.mmd` file or Mermaid code block:
   - `--use-ascii` - Use pure ASCII (no Unicode)
   - `--padding-x 5` - Horizontal spacing
   - `--padding-y 5` - Vertical spacing
+  - `--color-mode auto` - Terminal colors (`none`, `auto`, `ansi16`, `ansi256`, `truecolor`, or `html`)
 
 ### Advanced Options
 
@@ -146,6 +148,19 @@ node scripts/render.mjs \
   --output custom-font.svg
 ```
 
+**Layout and interactive XY charts**:
+```bash
+node scripts/render.mjs \
+  --input chart.mmd \
+  --node-spacing 32 \
+  --layer-spacing 56 \
+  --thoroughness 5 \
+  --interactive \
+  --output chart.svg
+```
+
+Use `--padding`, `--node-spacing`, `--layer-spacing`, and `--component-spacing` to tune ELK layout. `--interactive` enables hover tooltips for XY chart bars and points.
+
 ---
 
 ## Creating Diagrams
@@ -155,7 +170,7 @@ node scripts/render.mjs \
 **Step 1: List available templates**
 ```bash
 ls assets/example_diagrams/
-# flowchart.mmd  sequence.mmd  state.mmd  class.mmd  er.mmd
+# flowchart.mmd  sequence.mmd  state.mmd  class.mmd  er.mmd  xychart.mmd
 ```
 
 **Step 2: Copy and modify**
@@ -215,6 +230,17 @@ erDiagram
     ORDER ||--|{ ORDER_ITEM : contains
 ```
 
+**XY Chart** - Bar charts, line charts, trends, and comparisons
+```mermaid
+xychart-beta
+    title "Monthly Revenue"
+    x-axis [Jan, Feb, Mar]
+    bar [3200, 4100, 3800]
+    line [3000, 3700, 4200]
+```
+
+Flowcharts and state diagrams support `linkStyle`; state names may contain CJK text. SVG output supports `<br>` multiline labels and simple `<b>`, `<i>`, `<u>`, and `<s>` inline formatting.
+
 ### From User Requirements
 
 **Step 1: Identify diagram type**
@@ -223,6 +249,7 @@ erDiagram
 - **States/lifecycle** → State
 - **Object model** → Class
 - **Database** → ER
+- **Metrics/trends** → XY Chart
 
 **Step 2: Create diagram file**
 ```bash
@@ -265,10 +292,10 @@ Available Beautiful-Mermaid Themes:
  8. nord
  9. nord-light
 10. dracula
-11. github-dark
-12. github-light
-13. solarized-dark
-14. solarized-light
+11. github-light
+12. github-dark
+13. solarized-light
+14. solarized-dark
 15. one-dark
 
 Total: 15 themes
@@ -432,6 +459,16 @@ node scripts/render.mjs \
   --theme zinc-light
 ```
 
+### 6. Interactive Metrics Chart
+
+```bash
+node scripts/render.mjs \
+  --input metrics.mmd \
+  --output metrics.svg \
+  --theme github-light \
+  --interactive
+```
+
 ---
 
 ## Troubleshooting
@@ -486,6 +523,7 @@ Template files for quick diagram creation:
 - `example_diagrams/state.mmd` - State diagram template
 - `example_diagrams/class.mmd` - Class diagram template
 - `example_diagrams/er.mmd` - ER diagram template
+- `example_diagrams/xychart.mmd` - XY bar and line chart template
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -154,7 +154,6 @@ node scripts/render.mjs \
   --input chart.mmd \
   --node-spacing 32 \
   --layer-spacing 56 \
-  --thoroughness 5 \
   --interactive \
   --output chart.svg
 ```

--- a/assets/example_diagrams/xychart.mmd
+++ b/assets/example_diagrams/xychart.mmd
@@ -1,0 +1,6 @@
+xychart-beta
+    title "Monthly Revenue"
+    x-axis [Jan, Feb, Mar, Apr, May, Jun]
+    y-axis "Revenue" 0 --> 7000
+    bar [3200, 4100, 3800, 5200, 4900, 6100]
+    line [3000, 3700, 4200, 4600, 5300, 5900]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,48 @@
+{
+  "name": "pretty-mermaid-skill",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "pretty-mermaid-skill",
+      "version": "1.0.0",
+      "dependencies": {
+        "beautiful-mermaid": "^1.1.3"
+      },
+      "bin": {
+        "batch-mermaid": "scripts/batch.mjs",
+        "list-mermaid-themes": "scripts/themes.mjs",
+        "render-mermaid": "scripts/render.mjs"
+      }
+    },
+    "node_modules/beautiful-mermaid": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/beautiful-mermaid/-/beautiful-mermaid-1.1.3.tgz",
+      "integrity": "sha512-TItrtrAyHp1vwFfFVYauWGrquouk/6SS21Aq3RsxindSYZODcN4xYrPZD6BiZRU+o5mKJzDPz9MUSMvELdylyg==",
+      "license": "MIT",
+      "dependencies": {
+        "elkjs": "^0.11.0",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/elkjs": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/elkjs/-/elkjs-0.11.1.tgz",
+      "integrity": "sha512-zxxR9k+rx5ktMwT/FwyLdPCrq7xN6e4VGGHH8hA01vVYKjTFik7nHOxBnAYtrgYUB1RpAiLvA1/U2YraWxyKKg==",
+      "license": "EPL-2.0"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "batch-mermaid": "./scripts/batch.mjs",
     "list-mermaid-themes": "./scripts/themes.mjs"
   },
+  "scripts": {
+    "test": "node scripts/smoke-test.mjs"
+  },
   "dependencies": {
-    "beautiful-mermaid": "^0.1.3"
+    "beautiful-mermaid": "^1.1.3"
   }
 }

--- a/references/DIAGRAM_TYPES.md
+++ b/references/DIAGRAM_TYPES.md
@@ -31,6 +31,16 @@ flowchart LR
 - `--text-->` - Arrow with text
 - `-->|text|` - Arrow with text (alt syntax)
 
+### Edge Styling
+```mermaid
+flowchart LR
+    A --> B
+    B --> C
+    linkStyle 0 stroke:#7aa2f7,stroke-width:3px
+```
+
+`linkStyle` works in flowcharts and state diagrams. Target an edge by its zero-based declaration order, or use `linkStyle default` for all edges.
+
 ### Direction
 - `LR` - Left to Right
 - `RL` - Right to Left
@@ -175,6 +185,7 @@ stateDiagram-v2
 - Limit composite state depth to 2 levels
 - Group related states together
 - Use choice nodes for complex branching
+- State names and transition labels may contain Chinese, Japanese, Korean, and other Unicode text
 
 ---
 
@@ -291,6 +302,41 @@ erDiagram
 - Show only essential attributes
 - Keep relationship labels clear
 - Limit to 6-8 entities per diagram
+
+---
+
+## XY Chart
+
+### Bar and Line Series
+```mermaid
+xychart-beta
+    title "Monthly Revenue"
+    x-axis [Jan, Feb, Mar, Apr, May, Jun]
+    y-axis "Revenue" 0 --> 7000
+    bar [3200, 4100, 3800, 5200, 4900, 6100]
+    line [3000, 3700, 4200, 4600, 5300, 5900]
+```
+
+### Horizontal Charts
+```mermaid
+xychart-beta horizontal
+    title "Language Popularity"
+    x-axis [Python, JavaScript, Java, Go, Rust]
+    bar [30, 25, 20, 12, 8]
+```
+
+### Axis Configuration
+- Categorical axis: `x-axis [A, B, C]`
+- Numeric range: `x-axis 0 --> 100`
+- Axis title: `y-axis "Score" 0 --> 100`
+- Add multiple `bar` or `line` declarations for multi-series charts
+- Pass `--interactive` when rendering SVG to enable hover tooltips
+
+### Best Practices
+- Keep category labels short enough to avoid crowding
+- Set an explicit numeric range when series must be compared consistently
+- Use a combined bar and line chart only when the two series share a meaningful scale
+- Prefer ASCII output with `--color-mode none` for logs and stable snapshots
 
 ---
 

--- a/references/api_reference.md
+++ b/references/api_reference.md
@@ -34,7 +34,6 @@ Legacy aliases `renderMermaid` and `renderMermaidAscii` still exist in 1.1.3, bu
 | `nodeSpacing` | `24` | Horizontal spacing between sibling nodes |
 | `layerSpacing` | `40` | Vertical spacing between layers |
 | `componentSpacing` | `24` | Spacing between disconnected components |
-| `thoroughness` | `3` | Crossing-minimization trials from 1 to 7 |
 | `interactive` | `false` | Hover tooltips for XY chart bars and points |
 
 ## ASCII Options

--- a/references/api_reference.md
+++ b/references/api_reference.md
@@ -1,34 +1,55 @@
-# Reference Documentation for Beautiful Mermaid
+# beautiful-mermaid 1.1 API Reference
 
-This is a placeholder for detailed reference documentation.
-Replace with actual reference content or delete if not needed.
+Use this reference when extending the bundled CLI scripts or calling `beautiful-mermaid` directly. The Skill currently targets `beautiful-mermaid@^1.1.3`.
 
-Example real reference docs from other skills:
-- product-management/references/communication.md - Comprehensive guide for status updates
-- product-management/references/context_building.md - Deep-dive on gathering context
-- bigquery/references/ - API references and query examples
+## Rendering API
 
-## When Reference Docs Are Useful
+```js
+import {
+  renderMermaidSVG,
+  renderMermaidSVGAsync,
+  renderMermaidASCII,
+  THEMES,
+} from 'beautiful-mermaid';
+```
 
-Reference docs are ideal for:
-- Comprehensive API documentation
-- Detailed workflow guides
-- Complex multi-step processes
-- Information too lengthy for main SKILL.md
-- Content that's only needed for specific use cases
+- `renderMermaidSVG(text, options?)` returns an SVG string synchronously.
+- `renderMermaidSVGAsync(text, options?)` returns the same SVG as a promise.
+- `renderMermaidASCII(text, options?)` returns Unicode or plain ASCII terminal output.
+- `THEMES` contains the 15 built-in color themes.
+- `parseMermaid(text)` parses source into a graph for custom processing.
+- `fromShikiTheme(theme)` converts a Shiki theme to diagram colors.
 
-## Structure Suggestions
+Legacy aliases `renderMermaid` and `renderMermaidAscii` still exist in 1.1.3, but new code should use the canonical names above.
 
-### API Reference Example
-- Overview
-- Authentication
-- Endpoints with examples
-- Error codes
-- Rate limits
+## SVG Options
 
-### Workflow Guide Example
-- Prerequisites
-- Step-by-step instructions
-- Common patterns
-- Troubleshooting
-- Best practices
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `bg`, `fg` | zinc light colors | Base background and foreground colors |
+| `line`, `accent`, `muted`, `surface`, `border` | derived | Optional enriched theme colors |
+| `font` | `Inter` | Font family |
+| `transparent` | `false` | Transparent SVG background |
+| `padding` | `40` | Canvas padding in pixels |
+| `nodeSpacing` | `24` | Horizontal spacing between sibling nodes |
+| `layerSpacing` | `40` | Vertical spacing between layers |
+| `componentSpacing` | `24` | Spacing between disconnected components |
+| `thoroughness` | `3` | Crossing-minimization trials from 1 to 7 |
+| `interactive` | `false` | Hover tooltips for XY chart bars and points |
+
+## ASCII Options
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `useAscii` | `false` | Use plain ASCII instead of Unicode box drawing |
+| `paddingX` | `5` | Horizontal node spacing |
+| `paddingY` | `5` | Vertical node spacing |
+| `boxBorderPadding` | `1` | Inner box padding |
+| `colorMode` | `auto` | `none`, `auto`, `ansi16`, `ansi256`, `truecolor`, or `html` |
+| `theme` | none | Partial ASCII role-color overrides |
+
+## Supported Inputs
+
+The renderer auto-detects flowcharts, sequence diagrams, state diagrams, class diagrams, ER diagrams, and `xychart-beta`. Version 1.1 also supports `linkStyle`, CJK state names, multiline labels, disconnected components, and per-subgraph direction overrides.
+
+For exact upstream behavior, consult the [beautiful-mermaid README](https://github.com/lukilabs/beautiful-mermaid#readme) and [v1.x releases](https://github.com/lukilabs/beautiful-mermaid/releases).

--- a/scripts/batch.mjs
+++ b/scripts/batch.mjs
@@ -8,6 +8,21 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const skillRoot = join(__dirname, '..');
 
+function toAsciiTheme(colors) {
+  if (!colors) return undefined;
+
+  return {
+    fg: colors.fg,
+    border: colors.border ?? colors.fg,
+    line: colors.line ?? colors.fg,
+    arrow: colors.accent ?? colors.line ?? colors.fg,
+    accent: colors.accent ?? colors.fg,
+    bg: colors.bg,
+    corner: colors.border ?? colors.line ?? colors.fg,
+    junction: colors.accent ?? colors.border ?? colors.line ?? colors.fg,
+  };
+}
+
 async function loadBeautifulMermaid() {
   try {
     return await import('beautiful-mermaid');
@@ -61,7 +76,6 @@ function parseArgs() {
     nodeSpacing: 24,
     layerSpacing: 40,
     componentSpacing: 24,
-    thoroughness: 3,
     interactive: false,
     workers: 4,
   };
@@ -93,7 +107,6 @@ function parseArgs() {
       case '--node-spacing': opts.nodeSpacing = parseInt(val); i++; break;
       case '--layer-spacing': opts.layerSpacing = parseInt(val); i++; break;
       case '--component-spacing': opts.componentSpacing = parseInt(val); i++; break;
-      case '--thoroughness': opts.thoroughness = parseInt(val); i++; break;
       case '--interactive': opts.interactive = true; break;
       case '--workers': case '-w': opts.workers = parseInt(val); i++; break;
       case '--help': case '-h':
@@ -122,7 +135,6 @@ Options:
       --node-spacing <n>   SVG horizontal node spacing (default: 24)
       --layer-spacing <n>  SVG vertical layer spacing (default: 40)
       --component-spacing <n>  SVG disconnected component spacing (default: 24)
-      --thoroughness <n>   SVG layout trials, 1-7 (default: 3)
       --interactive        Enable XY chart hover tooltips (SVG only)
   -w, --workers <n>        Parallel workers (default: 4)`);
         process.exit(0);
@@ -151,6 +163,7 @@ async function renderFile(file, inputDir, outputDir, opts, lib) {
   const ext = opts.format === 'svg' ? '.svg' : '.txt';
   const outputPath = join(outputDir, file.replace(/\.mmd$/, ext));
   const input = readFileSync(inputPath, 'utf8');
+  const theme = opts.theme ? THEMES[opts.theme] : undefined;
 
   if (opts.format === 'ascii') {
     const ascii = renderMermaidASCII(input, {
@@ -159,10 +172,10 @@ async function renderFile(file, inputDir, outputDir, opts, lib) {
       paddingY: opts.paddingY,
       boxBorderPadding: opts.boxBorderPadding,
       colorMode: opts.colorMode,
+      theme: toAsciiTheme(theme),
     });
     writeFileSync(outputPath, ascii);
   } else {
-    const theme = opts.theme ? THEMES[opts.theme] : undefined;
     const colors = theme || {
       ...(opts.bg && { bg: opts.bg }),
       ...(opts.fg && { fg: opts.fg }),
@@ -181,7 +194,6 @@ async function renderFile(file, inputDir, outputDir, opts, lib) {
       nodeSpacing: opts.nodeSpacing,
       layerSpacing: opts.layerSpacing,
       componentSpacing: opts.componentSpacing,
-      thoroughness: opts.thoroughness,
       interactive: opts.interactive,
     });
     writeFileSync(outputPath, svg);

--- a/scripts/batch.mjs
+++ b/scripts/batch.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execSync } from 'child_process';
-import { dirname, join, resolve } from 'path';
+import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from 'fs';
 
@@ -45,8 +45,24 @@ function parseArgs() {
     theme: null,
     bg: null,
     fg: null,
+    line: null,
+    accent: null,
+    muted: null,
+    surface: null,
+    border: null,
+    font: 'Inter',
     transparent: false,
     useAscii: false,
+    paddingX: 5,
+    paddingY: 5,
+    boxBorderPadding: 1,
+    colorMode: 'auto',
+    padding: 40,
+    nodeSpacing: 24,
+    layerSpacing: 40,
+    componentSpacing: 24,
+    thoroughness: 3,
+    interactive: false,
     workers: 4,
   };
 
@@ -61,8 +77,24 @@ function parseArgs() {
       case '--theme': case '-t': opts.theme = val; i++; break;
       case '--bg': opts.bg = val; i++; break;
       case '--fg': opts.fg = val; i++; break;
+      case '--line': opts.line = val; i++; break;
+      case '--accent': opts.accent = val; i++; break;
+      case '--muted': opts.muted = val; i++; break;
+      case '--surface': opts.surface = val; i++; break;
+      case '--border': opts.border = val; i++; break;
+      case '--font': opts.font = val; i++; break;
       case '--transparent': opts.transparent = true; break;
       case '--use-ascii': opts.useAscii = true; break;
+      case '--padding-x': opts.paddingX = parseInt(val); i++; break;
+      case '--padding-y': opts.paddingY = parseInt(val); i++; break;
+      case '--box-border-padding': opts.boxBorderPadding = parseInt(val); i++; break;
+      case '--color-mode': opts.colorMode = val; i++; break;
+      case '--padding': opts.padding = parseInt(val); i++; break;
+      case '--node-spacing': opts.nodeSpacing = parseInt(val); i++; break;
+      case '--layer-spacing': opts.layerSpacing = parseInt(val); i++; break;
+      case '--component-spacing': opts.componentSpacing = parseInt(val); i++; break;
+      case '--thoroughness': opts.thoroughness = parseInt(val); i++; break;
+      case '--interactive': opts.interactive = true; break;
       case '--workers': case '-w': opts.workers = parseInt(val); i++; break;
       case '--help': case '-h':
         console.log(`Usage: node batch.mjs --input-dir <dir> --output-dir <dir> [options]
@@ -74,8 +106,24 @@ Options:
   -t, --theme <name>       Theme name (e.g. tokyo-night, dracula)
       --bg <hex>           Background color
       --fg <hex>           Foreground color
+      --line <hex>         Edge/connector color
+      --accent <hex>       Arrow heads and highlights color
+      --muted <hex>        Secondary text color
+      --surface <hex>      Node fill tint color
+      --border <hex>       Node stroke color
+      --font <name>        Font family (default: Inter)
       --transparent        Transparent background (SVG only)
       --use-ascii          Pure ASCII instead of Unicode (ASCII only)
+      --padding-x <n>      Horizontal spacing (ASCII only, default: 5)
+      --padding-y <n>      Vertical spacing (ASCII only, default: 5)
+      --box-border-padding <n>  Padding inside node boxes (ASCII only, default: 1)
+      --color-mode <mode>  ASCII colors: none | auto | ansi16 | ansi256 | truecolor | html
+      --padding <n>        SVG canvas padding in px (default: 40)
+      --node-spacing <n>   SVG horizontal node spacing (default: 24)
+      --layer-spacing <n>  SVG vertical layer spacing (default: 40)
+      --component-spacing <n>  SVG disconnected component spacing (default: 24)
+      --thoroughness <n>   SVG layout trials, 1-7 (default: 3)
+      --interactive        Enable XY chart hover tooltips (SVG only)
   -w, --workers <n>        Parallel workers (default: 4)`);
         process.exit(0);
     }
@@ -98,25 +146,43 @@ Options:
 }
 
 async function renderFile(file, inputDir, outputDir, opts, lib) {
-  const { renderMermaid, renderMermaidAscii, THEMES } = lib;
+  const { renderMermaidSVG, renderMermaidASCII, THEMES } = lib;
   const inputPath = join(inputDir, file);
   const ext = opts.format === 'svg' ? '.svg' : '.txt';
   const outputPath = join(outputDir, file.replace(/\.mmd$/, ext));
   const input = readFileSync(inputPath, 'utf8');
 
   if (opts.format === 'ascii') {
-    const ascii = renderMermaidAscii(input, { useAscii: opts.useAscii });
+    const ascii = renderMermaidASCII(input, {
+      useAscii: opts.useAscii,
+      paddingX: opts.paddingX,
+      paddingY: opts.paddingY,
+      boxBorderPadding: opts.boxBorderPadding,
+      colorMode: opts.colorMode,
+    });
     writeFileSync(outputPath, ascii);
   } else {
     const theme = opts.theme ? THEMES[opts.theme] : undefined;
     const colors = theme || {
       ...(opts.bg && { bg: opts.bg }),
       ...(opts.fg && { fg: opts.fg }),
+      ...(opts.line && { line: opts.line }),
+      ...(opts.accent && { accent: opts.accent }),
+      ...(opts.muted && { muted: opts.muted }),
+      ...(opts.surface && { surface: opts.surface }),
+      ...(opts.border && { border: opts.border }),
     };
 
-    const svg = await renderMermaid(input, {
+    const svg = renderMermaidSVG(input, {
       ...colors,
+      font: opts.font,
       transparent: opts.transparent,
+      padding: opts.padding,
+      nodeSpacing: opts.nodeSpacing,
+      layerSpacing: opts.layerSpacing,
+      componentSpacing: opts.componentSpacing,
+      thoroughness: opts.thoroughness,
+      interactive: opts.interactive,
     });
     writeFileSync(outputPath, svg);
   }
@@ -125,6 +191,10 @@ async function renderFile(file, inputDir, outputDir, opts, lib) {
 async function main() {
   const opts = parseArgs();
   const lib = await loadBeautifulMermaid();
+
+  if (opts.theme && !lib.THEMES[opts.theme]) {
+    throw new Error(`Unknown theme: ${opts.theme}. Run node scripts/themes.mjs to list themes.`);
+  }
 
   mkdirSync(opts.outputDir, { recursive: true });
 

--- a/scripts/batch.mjs
+++ b/scripts/batch.mjs
@@ -192,7 +192,7 @@ async function main() {
   const opts = parseArgs();
   const lib = await loadBeautifulMermaid();
 
-  if (opts.theme && !lib.THEMES[opts.theme]) {
+  if (opts.theme && !Object.prototype.hasOwnProperty.call(lib.THEMES, opts.theme)) {
     throw new Error(`Unknown theme: ${opts.theme}. Run node scripts/themes.mjs to list themes.`);
   }
 

--- a/scripts/batch.mjs
+++ b/scripts/batch.mjs
@@ -11,15 +11,21 @@ const skillRoot = join(__dirname, '..');
 function toAsciiTheme(colors) {
   if (!colors) return undefined;
 
+  const border = colors.border ?? colors.fg;
+  const line = colors.line ?? colors.fg;
+  const arrow = colors.accent ?? colors.line ?? colors.fg;
+  const corner = colors.border ?? colors.line ?? colors.fg;
+  const junction = colors.accent ?? colors.border ?? colors.line ?? colors.fg;
+
   return {
-    fg: colors.fg,
-    border: colors.border ?? colors.fg,
-    line: colors.line ?? colors.fg,
-    arrow: colors.accent ?? colors.line ?? colors.fg,
-    accent: colors.accent ?? colors.fg,
-    bg: colors.bg,
-    corner: colors.border ?? colors.line ?? colors.fg,
-    junction: colors.accent ?? colors.border ?? colors.line ?? colors.fg,
+    ...(colors.fg && { fg: colors.fg }),
+    ...(border && { border }),
+    ...(line && { line }),
+    ...(arrow && { arrow }),
+    ...(colors.accent && { accent: colors.accent }),
+    ...(colors.bg && { bg: colors.bg }),
+    ...(corner && { corner }),
+    ...(junction && { junction }),
   };
 }
 
@@ -164,6 +170,14 @@ async function renderFile(file, inputDir, outputDir, opts, lib) {
   const outputPath = join(outputDir, file.replace(/\.mmd$/, ext));
   const input = readFileSync(inputPath, 'utf8');
   const theme = opts.theme ? THEMES[opts.theme] : undefined;
+  const customColors = {
+    ...(opts.bg && { bg: opts.bg }),
+    ...(opts.fg && { fg: opts.fg }),
+    ...(opts.line && { line: opts.line }),
+    ...(opts.accent && { accent: opts.accent }),
+    ...(opts.border && { border: opts.border }),
+  };
+  const asciiColors = theme || (Object.keys(customColors).length > 0 ? customColors : undefined);
 
   if (opts.format === 'ascii') {
     const ascii = renderMermaidASCII(input, {
@@ -172,7 +186,7 @@ async function renderFile(file, inputDir, outputDir, opts, lib) {
       paddingY: opts.paddingY,
       boxBorderPadding: opts.boxBorderPadding,
       colorMode: opts.colorMode,
-      theme: toAsciiTheme(theme),
+      theme: toAsciiTheme(asciiColors),
     });
     writeFileSync(outputPath, ascii);
   } else {

--- a/scripts/render.mjs
+++ b/scripts/render.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { execSync } from 'child_process';
-import { dirname, join, resolve } from 'path';
+import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 
@@ -51,6 +51,13 @@ function parseArgs() {
     paddingX: 5,
     paddingY: 5,
     boxBorderPadding: 1,
+    colorMode: 'auto',
+    padding: 40,
+    nodeSpacing: 24,
+    layerSpacing: 40,
+    componentSpacing: 24,
+    thoroughness: 3,
+    interactive: false,
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -75,6 +82,13 @@ function parseArgs() {
       case '--padding-x': opts.paddingX = parseInt(val); i++; break;
       case '--padding-y': opts.paddingY = parseInt(val); i++; break;
       case '--box-border-padding': opts.boxBorderPadding = parseInt(val); i++; break;
+      case '--color-mode': opts.colorMode = val; i++; break;
+      case '--padding': opts.padding = parseInt(val); i++; break;
+      case '--node-spacing': opts.nodeSpacing = parseInt(val); i++; break;
+      case '--layer-spacing': opts.layerSpacing = parseInt(val); i++; break;
+      case '--component-spacing': opts.componentSpacing = parseInt(val); i++; break;
+      case '--thoroughness': opts.thoroughness = parseInt(val); i++; break;
+      case '--interactive': opts.interactive = true; break;
       case '--help': case '-h':
         console.log(`Usage: node render.mjs --input <file> [options]
 
@@ -95,7 +109,14 @@ Options:
       --use-ascii          Pure ASCII instead of Unicode (ASCII only)
       --padding-x <n>      Horizontal spacing (ASCII only, default: 5)
       --padding-y <n>      Vertical spacing (ASCII only, default: 5)
-      --box-border-padding <n>  Padding inside node boxes (ASCII only, default: 1)`);
+      --box-border-padding <n>  Padding inside node boxes (ASCII only, default: 1)
+      --color-mode <mode>  ASCII colors: none | auto | ansi16 | ansi256 | truecolor | html
+      --padding <n>        SVG canvas padding in px (default: 40)
+      --node-spacing <n>   SVG horizontal node spacing (default: 24)
+      --layer-spacing <n>  SVG vertical layer spacing (default: 40)
+      --component-spacing <n>  SVG disconnected component spacing (default: 24)
+      --thoroughness <n>   SVG layout trials, 1-7 (default: 3)
+      --interactive        Enable XY chart hover tooltips (SVG only)`);
         process.exit(0);
     }
   }
@@ -115,15 +136,20 @@ Options:
 
 async function main() {
   const opts = parseArgs();
-  const { renderMermaid, renderMermaidAscii, THEMES } = await loadBeautifulMermaid();
+  const { renderMermaidSVG, renderMermaidASCII, THEMES } = await loadBeautifulMermaid();
   const input = readFileSync(opts.input, 'utf8');
 
+  if (opts.theme && !THEMES[opts.theme]) {
+    throw new Error(`Unknown theme: ${opts.theme}. Run node scripts/themes.mjs to list themes.`);
+  }
+
   if (opts.format === 'ascii') {
-    const ascii = renderMermaidAscii(input, {
+    const ascii = renderMermaidASCII(input, {
       useAscii: opts.useAscii,
       paddingX: opts.paddingX,
       paddingY: opts.paddingY,
       boxBorderPadding: opts.boxBorderPadding,
+      colorMode: opts.colorMode,
     });
     if (opts.output) {
       writeFileSync(opts.output, ascii);
@@ -143,10 +169,16 @@ async function main() {
       ...(opts.border && { border: opts.border }),
     };
 
-    const svg = await renderMermaid(input, {
+    const svg = renderMermaidSVG(input, {
       ...colors,
       font: opts.font,
       transparent: opts.transparent,
+      padding: opts.padding,
+      nodeSpacing: opts.nodeSpacing,
+      layerSpacing: opts.layerSpacing,
+      componentSpacing: opts.componentSpacing,
+      thoroughness: opts.thoroughness,
+      interactive: opts.interactive,
     });
 
     if (opts.output) {

--- a/scripts/render.mjs
+++ b/scripts/render.mjs
@@ -11,15 +11,21 @@ const skillRoot = join(__dirname, '..');
 function toAsciiTheme(colors) {
   if (!colors) return undefined;
 
+  const border = colors.border ?? colors.fg;
+  const line = colors.line ?? colors.fg;
+  const arrow = colors.accent ?? colors.line ?? colors.fg;
+  const corner = colors.border ?? colors.line ?? colors.fg;
+  const junction = colors.accent ?? colors.border ?? colors.line ?? colors.fg;
+
   return {
-    fg: colors.fg,
-    border: colors.border ?? colors.fg,
-    line: colors.line ?? colors.fg,
-    arrow: colors.accent ?? colors.line ?? colors.fg,
-    accent: colors.accent ?? colors.fg,
-    bg: colors.bg,
-    corner: colors.border ?? colors.line ?? colors.fg,
-    junction: colors.accent ?? colors.border ?? colors.line ?? colors.fg,
+    ...(colors.fg && { fg: colors.fg }),
+    ...(border && { border }),
+    ...(line && { line }),
+    ...(arrow && { arrow }),
+    ...(colors.accent && { accent: colors.accent }),
+    ...(colors.bg && { bg: colors.bg }),
+    ...(corner && { corner }),
+    ...(junction && { junction }),
   };
 }
 
@@ -58,8 +64,8 @@ function parseArgs() {
     output: null,
     format: 'svg',
     theme: null,
-    bg: '#FFFFFF',
-    fg: '#27272A',
+    bg: null,
+    fg: null,
     font: 'Inter',
     transparent: false,
     useAscii: false,
@@ -155,6 +161,14 @@ async function main() {
     throw new Error(`Unknown theme: ${opts.theme}. Run node scripts/themes.mjs to list themes.`);
   }
   const theme = opts.theme ? THEMES[opts.theme] : undefined;
+  const customColors = {
+    ...(opts.bg && { bg: opts.bg }),
+    ...(opts.fg && { fg: opts.fg }),
+    ...(opts.line && { line: opts.line }),
+    ...(opts.accent && { accent: opts.accent }),
+    ...(opts.border && { border: opts.border }),
+  };
+  const asciiColors = theme || (Object.keys(customColors).length > 0 ? customColors : undefined);
 
   if (opts.format === 'ascii') {
     const ascii = renderMermaidASCII(input, {
@@ -163,7 +177,7 @@ async function main() {
       paddingY: opts.paddingY,
       boxBorderPadding: opts.boxBorderPadding,
       colorMode: opts.colorMode,
-      theme: toAsciiTheme(theme),
+      theme: toAsciiTheme(asciiColors),
     });
     if (opts.output) {
       writeFileSync(opts.output, ascii);
@@ -173,8 +187,8 @@ async function main() {
     }
   } else {
     const colors = theme || {
-      bg: opts.bg,
-      fg: opts.fg,
+      bg: opts.bg ?? '#FFFFFF',
+      fg: opts.fg ?? '#27272A',
       ...(opts.line && { line: opts.line }),
       ...(opts.accent && { accent: opts.accent }),
       ...(opts.muted && { muted: opts.muted }),

--- a/scripts/render.mjs
+++ b/scripts/render.mjs
@@ -139,7 +139,7 @@ async function main() {
   const { renderMermaidSVG, renderMermaidASCII, THEMES } = await loadBeautifulMermaid();
   const input = readFileSync(opts.input, 'utf8');
 
-  if (opts.theme && !THEMES[opts.theme]) {
+  if (opts.theme && !Object.prototype.hasOwnProperty.call(THEMES, opts.theme)) {
     throw new Error(`Unknown theme: ${opts.theme}. Run node scripts/themes.mjs to list themes.`);
   }
 

--- a/scripts/render.mjs
+++ b/scripts/render.mjs
@@ -8,6 +8,21 @@ import { readFileSync, writeFileSync, existsSync } from 'fs';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const skillRoot = join(__dirname, '..');
 
+function toAsciiTheme(colors) {
+  if (!colors) return undefined;
+
+  return {
+    fg: colors.fg,
+    border: colors.border ?? colors.fg,
+    line: colors.line ?? colors.fg,
+    arrow: colors.accent ?? colors.line ?? colors.fg,
+    accent: colors.accent ?? colors.fg,
+    bg: colors.bg,
+    corner: colors.border ?? colors.line ?? colors.fg,
+    junction: colors.accent ?? colors.border ?? colors.line ?? colors.fg,
+  };
+}
+
 async function loadBeautifulMermaid() {
   try {
     return await import('beautiful-mermaid');
@@ -56,7 +71,6 @@ function parseArgs() {
     nodeSpacing: 24,
     layerSpacing: 40,
     componentSpacing: 24,
-    thoroughness: 3,
     interactive: false,
   };
 
@@ -87,7 +101,6 @@ function parseArgs() {
       case '--node-spacing': opts.nodeSpacing = parseInt(val); i++; break;
       case '--layer-spacing': opts.layerSpacing = parseInt(val); i++; break;
       case '--component-spacing': opts.componentSpacing = parseInt(val); i++; break;
-      case '--thoroughness': opts.thoroughness = parseInt(val); i++; break;
       case '--interactive': opts.interactive = true; break;
       case '--help': case '-h':
         console.log(`Usage: node render.mjs --input <file> [options]
@@ -115,7 +128,6 @@ Options:
       --node-spacing <n>   SVG horizontal node spacing (default: 24)
       --layer-spacing <n>  SVG vertical layer spacing (default: 40)
       --component-spacing <n>  SVG disconnected component spacing (default: 24)
-      --thoroughness <n>   SVG layout trials, 1-7 (default: 3)
       --interactive        Enable XY chart hover tooltips (SVG only)`);
         process.exit(0);
     }
@@ -142,6 +154,7 @@ async function main() {
   if (opts.theme && !Object.prototype.hasOwnProperty.call(THEMES, opts.theme)) {
     throw new Error(`Unknown theme: ${opts.theme}. Run node scripts/themes.mjs to list themes.`);
   }
+  const theme = opts.theme ? THEMES[opts.theme] : undefined;
 
   if (opts.format === 'ascii') {
     const ascii = renderMermaidASCII(input, {
@@ -150,6 +163,7 @@ async function main() {
       paddingY: opts.paddingY,
       boxBorderPadding: opts.boxBorderPadding,
       colorMode: opts.colorMode,
+      theme: toAsciiTheme(theme),
     });
     if (opts.output) {
       writeFileSync(opts.output, ascii);
@@ -158,7 +172,6 @@ async function main() {
       console.log(ascii);
     }
   } else {
-    const theme = opts.theme ? THEMES[opts.theme] : undefined;
     const colors = theme || {
       bg: opts.bg,
       fg: opts.fg,
@@ -177,7 +190,6 @@ async function main() {
       nodeSpacing: opts.nodeSpacing,
       layerSpacing: opts.layerSpacing,
       componentSpacing: opts.componentSpacing,
-      thoroughness: opts.thoroughness,
       interactive: opts.interactive,
     });
 

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -1,7 +1,9 @@
 #!/usr/bin/env node
 
 import assert from 'node:assert/strict';
-import { readdirSync, readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import {
@@ -13,6 +15,7 @@ import {
 const scriptsDir = dirname(fileURLToPath(import.meta.url));
 const examplesDir = join(scriptsDir, '..', 'assets', 'example_diagrams');
 const files = readdirSync(examplesDir).filter(file => file.endsWith('.mmd')).sort();
+const inheritedThemeNames = ['toString', 'constructor', '__proto__'];
 
 assert.equal(files.length, 6, 'Expected six example diagrams');
 assert.equal(Object.keys(THEMES).length, 15, 'Expected 15 built-in themes');
@@ -26,4 +29,30 @@ for (const file of files) {
   assert.ok(ascii.trim().length > 0, `${file} did not render ASCII output`);
 }
 
-console.log(`Smoke tests passed: ${files.length} diagrams x 2 formats, 15 themes.`);
+const cliTestDir = mkdtempSync(join(tmpdir(), 'pretty-mermaid-smoke-'));
+const flowchartPath = join(examplesDir, 'flowchart.mmd');
+
+try {
+  for (const themeName of inheritedThemeNames) {
+    const renderResult = spawnSync(process.execPath, [
+      join(scriptsDir, 'render.mjs'),
+      '--input', flowchartPath,
+      '--theme', themeName,
+    ], { encoding: 'utf8' });
+    assert.notEqual(renderResult.status, 0, `render.mjs accepted inherited theme: ${themeName}`);
+    assert.match(renderResult.stderr, /Unknown theme:/);
+
+    const batchResult = spawnSync(process.execPath, [
+      join(scriptsDir, 'batch.mjs'),
+      '--input-dir', examplesDir,
+      '--output-dir', join(cliTestDir, themeName),
+      '--theme', themeName,
+    ], { encoding: 'utf8' });
+    assert.notEqual(batchResult.status, 0, `batch.mjs accepted inherited theme: ${themeName}`);
+    assert.match(batchResult.stderr, /Unknown theme:/);
+  }
+} finally {
+  rmSync(cliTestDir, { recursive: true, force: true });
+}
+
+console.log(`Smoke tests passed: ${files.length} diagrams x 2 formats, 15 themes, inherited theme rejection.`);

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -32,6 +32,19 @@ for (const file of files) {
 const cliTestDir = mkdtempSync(join(tmpdir(), 'pretty-mermaid-smoke-'));
 const flowchartPath = join(examplesDir, 'flowchart.mmd');
 const xychartPath = join(examplesDir, 'xychart.mmd');
+const customColorArgs = [
+  '--bg', '#ffffff',
+  '--fg', '#123456',
+  '--line', '#abcdef',
+  '--accent', '#fedcba',
+  '--border', '#0f0f0f',
+];
+const customColorCodes = [
+  '\u001b[38;2;18;52;86m',
+  '\u001b[38;2;171;205;239m',
+  '\u001b[38;2;254;220;186m',
+  '\u001b[38;2;15;15;15m',
+];
 
 try {
   for (const themeName of inheritedThemeNames) {
@@ -100,8 +113,38 @@ try {
     readFileSync(join(batchThemedAsciiDir, 'flowchart.txt'), 'utf8'),
     /\u001b\[38;2;248;248;242m/,
   );
+
+  const customAsciiPath = join(cliTestDir, 'custom.txt');
+  const renderCustomAsciiResult = spawnSync(process.execPath, [
+    join(scriptsDir, 'render.mjs'),
+    '--input', flowchartPath,
+    '--output', customAsciiPath,
+    '--format', 'ascii',
+    '--color-mode', 'truecolor',
+    ...customColorArgs,
+  ], { encoding: 'utf8' });
+  assert.equal(renderCustomAsciiResult.status, 0, renderCustomAsciiResult.stderr);
+  const customAscii = readFileSync(customAsciiPath, 'utf8');
+  for (const colorCode of customColorCodes) {
+    assert.ok(customAscii.includes(colorCode), `render.mjs omitted custom ASCII color ${colorCode}`);
+  }
+
+  const batchCustomAsciiDir = join(cliTestDir, 'batch-custom');
+  const batchCustomAsciiResult = spawnSync(process.execPath, [
+    join(scriptsDir, 'batch.mjs'),
+    '--input-dir', examplesDir,
+    '--output-dir', batchCustomAsciiDir,
+    '--format', 'ascii',
+    '--color-mode', 'truecolor',
+    ...customColorArgs,
+  ], { encoding: 'utf8' });
+  assert.equal(batchCustomAsciiResult.status, 0, batchCustomAsciiResult.stderr);
+  const batchCustomAscii = readFileSync(join(batchCustomAsciiDir, 'flowchart.txt'), 'utf8');
+  for (const colorCode of customColorCodes) {
+    assert.ok(batchCustomAscii.includes(colorCode), `batch.mjs omitted custom ASCII color ${colorCode}`);
+  }
 } finally {
   rmSync(cliTestDir, { recursive: true, force: true });
 }
 
-console.log(`Smoke tests passed: ${files.length} diagrams x 2 formats, 15 themes, CLI theme and interactive coverage.`);
+console.log(`Smoke tests passed: ${files.length} diagrams x 2 formats, 15 themes, CLI named/custom colors and interactive coverage.`);

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -31,6 +31,7 @@ for (const file of files) {
 
 const cliTestDir = mkdtempSync(join(tmpdir(), 'pretty-mermaid-smoke-'));
 const flowchartPath = join(examplesDir, 'flowchart.mmd');
+const xychartPath = join(examplesDir, 'xychart.mmd');
 
 try {
   for (const themeName of inheritedThemeNames) {
@@ -51,8 +52,56 @@ try {
     assert.notEqual(batchResult.status, 0, `batch.mjs accepted inherited theme: ${themeName}`);
     assert.match(batchResult.stderr, /Unknown theme:/);
   }
+
+  const interactiveSvgPath = join(cliTestDir, 'interactive.svg');
+  const renderInteractiveResult = spawnSync(process.execPath, [
+    join(scriptsDir, 'render.mjs'),
+    '--input', xychartPath,
+    '--output', interactiveSvgPath,
+    '--interactive',
+  ], { encoding: 'utf8' });
+  assert.equal(renderInteractiveResult.status, 0, renderInteractiveResult.stderr);
+  assert.match(readFileSync(interactiveSvgPath, 'utf8'), /class="xychart-tip/);
+
+  const batchInteractiveDir = join(cliTestDir, 'batch-interactive');
+  const batchInteractiveResult = spawnSync(process.execPath, [
+    join(scriptsDir, 'batch.mjs'),
+    '--input-dir', examplesDir,
+    '--output-dir', batchInteractiveDir,
+    '--interactive',
+  ], { encoding: 'utf8' });
+  assert.equal(batchInteractiveResult.status, 0, batchInteractiveResult.stderr);
+  assert.match(batchInteractiveResult.stdout, /xychart\.mmd/);
+  assert.match(readFileSync(join(batchInteractiveDir, 'xychart.svg'), 'utf8'), /class="xychart-tip/);
+
+  const themedAsciiPath = join(cliTestDir, 'dracula.txt');
+  const renderThemedAsciiResult = spawnSync(process.execPath, [
+    join(scriptsDir, 'render.mjs'),
+    '--input', flowchartPath,
+    '--output', themedAsciiPath,
+    '--format', 'ascii',
+    '--color-mode', 'truecolor',
+    '--theme', 'dracula',
+  ], { encoding: 'utf8' });
+  assert.equal(renderThemedAsciiResult.status, 0, renderThemedAsciiResult.stderr);
+  assert.match(readFileSync(themedAsciiPath, 'utf8'), /\u001b\[38;2;248;248;242m/);
+
+  const batchThemedAsciiDir = join(cliTestDir, 'batch-dracula');
+  const batchThemedAsciiResult = spawnSync(process.execPath, [
+    join(scriptsDir, 'batch.mjs'),
+    '--input-dir', examplesDir,
+    '--output-dir', batchThemedAsciiDir,
+    '--format', 'ascii',
+    '--color-mode', 'truecolor',
+    '--theme', 'dracula',
+  ], { encoding: 'utf8' });
+  assert.equal(batchThemedAsciiResult.status, 0, batchThemedAsciiResult.stderr);
+  assert.match(
+    readFileSync(join(batchThemedAsciiDir, 'flowchart.txt'), 'utf8'),
+    /\u001b\[38;2;248;248;242m/,
+  );
 } finally {
   rmSync(cliTestDir, { recursive: true, force: true });
 }
 
-console.log(`Smoke tests passed: ${files.length} diagrams x 2 formats, 15 themes, inherited theme rejection.`);
+console.log(`Smoke tests passed: ${files.length} diagrams x 2 formats, 15 themes, CLI theme and interactive coverage.`);

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -1,0 +1,29 @@
+#!/usr/bin/env node
+
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  renderMermaidASCII,
+  renderMermaidSVG,
+  THEMES,
+} from 'beautiful-mermaid';
+
+const scriptsDir = dirname(fileURLToPath(import.meta.url));
+const examplesDir = join(scriptsDir, '..', 'assets', 'example_diagrams');
+const files = readdirSync(examplesDir).filter(file => file.endsWith('.mmd')).sort();
+
+assert.equal(files.length, 6, 'Expected six example diagrams');
+assert.equal(Object.keys(THEMES).length, 15, 'Expected 15 built-in themes');
+
+for (const file of files) {
+  const source = readFileSync(join(examplesDir, file), 'utf8');
+  const svg = renderMermaidSVG(source, THEMES['tokyo-night']);
+  const ascii = renderMermaidASCII(source, { colorMode: 'none' });
+
+  assert.ok(svg.startsWith('<svg'), `${file} did not render valid SVG`);
+  assert.ok(ascii.trim().length > 0, `${file} did not render ASCII output`);
+}
+
+console.log(`Smoke tests passed: ${files.length} diagrams x 2 formats, 15 themes.`);


### PR DESCRIPTION
## Summary
- upgrade beautiful-mermaid from 0.1.3 to 1.1.3 and add a reproducible lockfile
- migrate the render CLIs to canonical SVG and ASCII APIs with new layout, interaction, color, and validation options
- add XY chart coverage, smoke tests, and synchronized Skill and reference documentation

## Verification
- npm ci --ignore-scripts --registry=https://registry.npmjs.org
- npm test: 6 diagrams x 2 formats, 15 themes
- XY chart SVG and ASCII CLI output, including interactive SVG data
- Node 16, 18, 20, and 22 smoke tests
- Skill quick validation
- npm audit --omit=dev: 0 vulnerabilities
- node --check for all scripts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added XY chart support with bar and line series examples.
  * Added configurable colors, themes, spacing, layouts, and interactive SVG output.
  * Added flowchart and state diagram edge styling options.
* **Bug Fixes**
  * Corrected the Catppuccin Latte theme name and improved theme validation.
  * Updated rendering workflows for current capabilities.
* **Documentation**
  * Expanded English and Chinese guides, API references, chart examples, and renderer guidance.
* **Tests**
  * Added smoke tests covering diagrams, themes, SVG, ASCII, custom colors, and interactive rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->