### PR TITLE
render: default to writing a file instead of dumping to stdout

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -25,10 +25,18 @@ Treat the directory containing this file as `<skill-root>`. Run bundled scripts 
 3. Read only the relevant reference file when syntax, theme selection, or API behavior needs more detail.
 4. Save new source as a `.mmd` file, preserving user terminology and relationships.
 5. Render with a named theme or explicit colors.
-6. Inspect the result. Fix syntax, clipping, crowded layout, or unclear labels and render again.
+6. Check the CLI error output; fix syntax, labels, or spacing and render again.
 7. Return the source and output paths, plus the selected format and theme.
 
 Do not overwrite an existing source or output file unless the user asked for replacement.
+
+## Output discipline
+
+Rendered files stay on disk; only paths and receipts travel through the conversation.
+
+- Pass `--output <file>` on every render to place the file deliberately; omitting it writes `<input>.svg`/`.txt`/`.png` beside the source. Nothing is ever printed to stdout.
+- Probe output with cheap commands (`wc -c`, `head -c 20`); never `cat` a rendered file.
+- Visual inspection is the user's: hand back the file path; for a terminal preview, suggest `cat <file>`.
 
 ## Choose a diagram type
 
@@ -173,9 +181,9 @@ Run `node scripts/render.mjs --help` or `node scripts/batch.mjs --help` for the 
 
 After rendering:
 
-1. Confirm the command exits successfully and the output file is non-empty.
-2. Confirm SVG output begins with `<svg`; confirm PNG output opens as a valid image; confirm text output contains visible diagram content.
-3. Inspect visual output when layout matters, especially long labels, CJK text, disconnected components, and XY charts.
+1. Confirm the command exits successfully and the output file is non-empty: `wc -c <file>`.
+2. Probe structure only: SVG starts with `<svg` (`head -c 20 <file>`); PNG is a valid image (`file <file>`); text output shows diagram content in its first lines (`head -n 5 <file>`).
+3. Leave visual inspection to the user when layout matters — long labels, CJK text, disconnected components, XY charts — by reporting the output path.
 4. Confirm arrows, cardinalities, states, and labels match the source request.
 5. Report any renderer limitation instead of silently dropping unsupported syntax.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -23,7 +23,7 @@ Treat the directory containing this file as `<skill-root>`. Run bundled scripts 
 1. Determine whether the user supplied Mermaid source or needs a diagram authored from prose.
 2. Choose the diagram type and output format from the tables below.
 3. Read only the relevant reference file when syntax, theme selection, or API behavior needs more detail.
-4. Save new source as a `.mmd` file, preserving user terminology and relationships.
+4. Save new source as a `.mmd` file, preserving user terminology and relationships. For non-trivial syntax, consult `references/DIAGRAM_TYPES.md` before saving to avoid render-retry loops.
 5. Render with a named theme or explicit colors.
 6. Check the CLI error output; fix syntax, labels, or spacing and render again.
 7. Return the source and output paths, plus the selected format and theme.
@@ -37,6 +37,7 @@ Rendered files stay on disk; only paths and receipts travel through the conversa
 - Pass `--output <file>` on every render to place the file deliberately; omitting it writes `<input>.svg`/`.txt`/`.png` beside the source. Rendered content is never printed to stdout — the CLI only reports the saved path.
 - Existing output files are refused by default; pass `--force` only when the user asked for replacement.
 - Probe output with cheap commands (`wc -c`, `head -c 20`) instead of dumping rendered files.
+- Re-render the same diagram at most twice; if it still fails, report the renderer limitation (see Validation) instead of continuing to retry.
 - Visual inspection is the user's: hand back the file path.
 
 ## Choose a diagram type
@@ -125,7 +126,7 @@ Use batch rendering for three or more diagrams or when consistent options must b
 - High-contrast color: `dracula`
 - Cool, restrained palette: `nord`, `nord-light`
 
-Read `references/THEMES.md` or open `docs/THEME_GALLERY.md` when visual theme choice matters. A named theme can be refined with explicit color flags.
+Read `references/THEMES.md` or open `docs/THEME_GALLERY.md` when visual theme choice matters. A named theme can be refined with explicit color flags. When the task does not specify a theme, use the first suitable recommendation above instead of sampling multiple themes.
 
 ## Useful options
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -28,15 +28,16 @@ Treat the directory containing this file as `<skill-root>`. Run bundled scripts 
 6. Check the CLI error output; fix syntax, labels, or spacing and render again.
 7. Return the source and output paths, plus the selected format and theme.
 
-Do not overwrite an existing source or output file unless the user asked for replacement.
+Do not overwrite an existing source or output file unless the user asked for replacement (the CLI refuses unless `--force` is passed).
 
 ## Output discipline
 
 Rendered files stay on disk; only paths and receipts travel through the conversation.
 
-- Pass `--output <file>` on every render to place the file deliberately; omitting it writes `<input>.svg`/`.txt`/`.png` beside the source. Nothing is ever printed to stdout.
-- Probe output with cheap commands (`wc -c`, `head -c 20`); never `cat` a rendered file.
-- Visual inspection is the user's: hand back the file path; for a terminal preview, suggest `cat <file>`.
+- Pass `--output <file>` on every render to place the file deliberately; omitting it writes `<input>.svg`/`.txt`/`.png` beside the source. Rendered content is never printed to stdout — the CLI only reports the saved path.
+- Existing output files are refused by default; pass `--force` only when the user asked for replacement.
+- Probe output with cheap commands (`wc -c`, `head -c 20`) instead of dumping rendered files.
+- Visual inspection is the user's: hand back the file path.
 
 ## Choose a diagram type
 

--- a/scripts/batch.mjs
+++ b/scripts/batch.mjs
@@ -84,6 +84,7 @@ function parseArgs() {
     layerSpacing: 40,
     componentSpacing: 24,
     interactive: false,
+    force: false,
     workers: 4,
     width: DEFAULT_PNG_WIDTH,
   };
@@ -116,6 +117,7 @@ function parseArgs() {
       case '--layer-spacing': opts.layerSpacing = parseInt(val); i++; break;
       case '--component-spacing': opts.componentSpacing = parseInt(val); i++; break;
       case '--interactive': opts.interactive = true; break;
+      case '--force': opts.force = true; break;
       case '--workers': case '-w': opts.workers = parseInt(val); i++; break;
       case '--width':
         if (val === undefined) throw new Error('--width requires a value.');
@@ -126,6 +128,7 @@ function parseArgs() {
 Options:
   -i, --input-dir <dir>    Input directory containing .mmd files [required]
   -o, --output-dir <dir>   Output directory for rendered files [required]
+      --force              Overwrite existing output files (default: refuse)
   -f, --format <fmt>       Output format: svg | png | ascii (default: svg)
   -t, --theme <name>       Theme name (e.g. tokyo-night, dracula)
       --bg <hex>           Background color
@@ -184,6 +187,9 @@ async function renderFile(file, inputDir, outputDir, opts, lib) {
   const ext = opts.format === 'svg' ? '.svg' : opts.format === 'png' ? '.png' : '.txt';
   const outputPath = join(outputDir, file.replace(/\.mmd$/, ext));
   const input = readFileSync(inputPath, 'utf8');
+  if (existsSync(outputPath) && !opts.force) {
+    throw new Error(`Output file already exists: ${outputPath} (pass --force to replace)`);
+  }
   const theme = opts.theme ? THEMES[opts.theme] : undefined;
   const customColors = {
     ...(opts.bg && { bg: opts.bg }),

--- a/scripts/batch.mjs
+++ b/scripts/batch.mjs
@@ -181,15 +181,25 @@ Options:
   return opts;
 }
 
+function writeRendered(outputPath, content, force) {
+  // 'wx' = exclusive create: the no-overwrite check and the write are one atomic
+  // step, so a concurrent process cannot slip a file into the TOCTOU window.
+  try {
+    writeFileSync(outputPath, content, { flag: force ? 'w' : 'wx' });
+  } catch (e) {
+    if (e.code === 'EEXIST') {
+      throw new Error(`Output file already exists: ${outputPath} (pass --force to replace)`);
+    }
+    throw e;
+  }
+}
+
 async function renderFile(file, inputDir, outputDir, opts, lib) {
   const { renderMermaidSVG, renderMermaidASCII, THEMES } = lib;
   const inputPath = join(inputDir, file);
   const ext = opts.format === 'svg' ? '.svg' : opts.format === 'png' ? '.png' : '.txt';
   const outputPath = join(outputDir, file.replace(/\.mmd$/, ext));
   const input = readFileSync(inputPath, 'utf8');
-  if (existsSync(outputPath) && !opts.force) {
-    throw new Error(`Output file already exists: ${outputPath} (pass --force to replace)`);
-  }
   const theme = opts.theme ? THEMES[opts.theme] : undefined;
   const customColors = {
     ...(opts.bg && { bg: opts.bg }),
@@ -209,7 +219,7 @@ async function renderFile(file, inputDir, outputDir, opts, lib) {
       colorMode: opts.colorMode,
       theme: toAsciiTheme(asciiColors),
     });
-    writeFileSync(outputPath, ascii);
+    writeRendered(outputPath, ascii, opts.force);
   } else {
     const colors = theme || {
       ...(opts.bg && { bg: opts.bg }),
@@ -231,7 +241,7 @@ async function renderFile(file, inputDir, outputDir, opts, lib) {
       componentSpacing: opts.componentSpacing,
       interactive: opts.interactive,
     });
-    writeFileSync(outputPath, opts.format === 'png' ? renderSvgToPng(svg, opts.width) : svg);
+    writeRendered(outputPath, opts.format === 'png' ? renderSvgToPng(svg, opts.width) : svg, opts.force);
   }
 }
 

--- a/scripts/render.mjs
+++ b/scripts/render.mjs
@@ -175,10 +175,16 @@ function defaultOutputPath(input, ext) {
 }
 
 function writeRendered(outputPath, content, force) {
-  if (existsSync(outputPath) && !force) {
-    throw new Error(`Output file already exists: ${outputPath} (pass --force to replace)`);
+  // 'wx' = exclusive create: the no-overwrite check and the write are one atomic
+  // step, so a concurrent process cannot slip a file into the TOCTOU window.
+  try {
+    writeFileSync(outputPath, content, { flag: force ? 'w' : 'wx' });
+  } catch (e) {
+    if (e.code === 'EEXIST') {
+      throw new Error(`Output file already exists: ${outputPath} (pass --force to replace)`);
+    }
+    throw e;
   }
-  writeFileSync(outputPath, content);
 }
 
 async function main() {

--- a/scripts/render.mjs
+++ b/scripts/render.mjs
@@ -118,7 +118,7 @@ function parseArgs() {
 
 Options:
   -i, --input <file>       Input Mermaid file (.mmd) [required]
-  -o, --output <file>      Output file (default: stdout; input.png for PNG)
+  -o, --output <file>      Output file (default: <input>.svg/.txt/.png by format)
   -f, --format <fmt>       Output format: svg | png | ascii (default: svg)
   -t, --theme <name>       Theme name (e.g. tokyo-night, dracula)
       --bg <hex>           Background color
@@ -167,6 +167,10 @@ Options:
   return opts;
 }
 
+function defaultOutputPath(input, ext) {
+  return /\.mmd$/i.test(input) ? input.replace(/\.mmd$/i, `.${ext}`) : `${input}.${ext}`;
+}
+
 async function main() {
   const opts = parseArgs();
   const { renderMermaidSVG, renderMermaidASCII, THEMES } = await loadBeautifulMermaid();
@@ -194,12 +198,9 @@ async function main() {
       colorMode: opts.colorMode,
       theme: toAsciiTheme(asciiColors),
     });
-    if (opts.output) {
-      writeFileSync(opts.output, ascii);
-      console.log(`ASCII diagram saved to ${opts.output}`);
-    } else {
-      console.log(ascii);
-    }
+    const outputPath = opts.output || defaultOutputPath(opts.input, 'txt');
+    writeFileSync(outputPath, ascii);
+    console.log(`ASCII diagram saved to ${outputPath}`);
   } else {
     const colors = theme || {
       bg: opts.bg ?? '#FFFFFF',
@@ -222,18 +223,11 @@ async function main() {
       interactive: opts.interactive,
     });
 
-    if (opts.format === 'png') {
-      const outputPath = opts.output || (
-        /\.mmd$/i.test(opts.input) ? opts.input.replace(/\.mmd$/i, '.png') : `${opts.input}.png`
-      );
-      writeFileSync(outputPath, renderSvgToPng(svg, opts.width));
-      console.log(`PNG diagram saved to ${outputPath}`);
-    } else if (opts.output) {
-      writeFileSync(opts.output, svg);
-      console.log(`SVG diagram saved to ${opts.output}`);
-    } else {
-      console.log(svg);
-    }
+    const ext = opts.format === 'png' ? 'png' : 'svg';
+    const outputPath = opts.output || defaultOutputPath(opts.input, ext);
+    const content = opts.format === 'png' ? renderSvgToPng(svg, opts.width) : svg;
+    writeFileSync(outputPath, content);
+    console.log(`${opts.format.toUpperCase()} diagram saved to ${outputPath}`);
   }
 }
 

--- a/scripts/render.mjs
+++ b/scripts/render.mjs
@@ -63,6 +63,7 @@ function parseArgs() {
   const opts = {
     input: null,
     output: null,
+    force: false,
     format: 'svg',
     theme: null,
     bg: null,
@@ -100,6 +101,7 @@ function parseArgs() {
       case '--border': opts.border = val; i++; break;
       case '--font': opts.font = val; i++; break;
       case '--transparent': opts.transparent = true; break;
+      case '--force': opts.force = true; break;
       case '--use-ascii': opts.useAscii = true; break;
       case '--padding-x': opts.paddingX = parseInt(val); i++; break;
       case '--padding-y': opts.paddingY = parseInt(val); i++; break;
@@ -119,6 +121,7 @@ function parseArgs() {
 Options:
   -i, --input <file>       Input Mermaid file (.mmd) [required]
   -o, --output <file>      Output file (default: <input>.svg/.txt/.png by format)
+      --force              Overwrite existing output files (default: refuse)
   -f, --format <fmt>       Output format: svg | png | ascii (default: svg)
   -t, --theme <name>       Theme name (e.g. tokyo-night, dracula)
       --bg <hex>           Background color
@@ -171,6 +174,13 @@ function defaultOutputPath(input, ext) {
   return /\.mmd$/i.test(input) ? input.replace(/\.mmd$/i, `.${ext}`) : `${input}.${ext}`;
 }
 
+function writeRendered(outputPath, content, force) {
+  if (existsSync(outputPath) && !force) {
+    throw new Error(`Output file already exists: ${outputPath} (pass --force to replace)`);
+  }
+  writeFileSync(outputPath, content);
+}
+
 async function main() {
   const opts = parseArgs();
   const { renderMermaidSVG, renderMermaidASCII, THEMES } = await loadBeautifulMermaid();
@@ -199,7 +209,7 @@ async function main() {
       theme: toAsciiTheme(asciiColors),
     });
     const outputPath = opts.output || defaultOutputPath(opts.input, 'txt');
-    writeFileSync(outputPath, ascii);
+    writeRendered(outputPath, ascii, opts.force);
     console.log(`ASCII diagram saved to ${outputPath}`);
   } else {
     const colors = theme || {
@@ -226,7 +236,7 @@ async function main() {
     const ext = opts.format === 'png' ? 'png' : 'svg';
     const outputPath = opts.output || defaultOutputPath(opts.input, ext);
     const content = opts.format === 'png' ? renderSvgToPng(svg, opts.width) : svg;
-    writeFileSync(outputPath, content);
+    writeRendered(outputPath, content, opts.force);
     console.log(`${opts.format.toUpperCase()} diagram saved to ${outputPath}`);
   }
 }

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -237,6 +237,7 @@ try {
     '--output', guardPath,
   ], { encoding: 'utf8' });
   assert.equal(guardFirstRender.status, 0, guardFirstRender.stderr);
+  const guardContentBefore = readFileSync(guardPath, 'utf8');
 
   const guardRerunResult = spawnSync(process.execPath, [
     join(scriptsDir, 'render.mjs'),
@@ -259,10 +260,29 @@ try {
     '--input', flowchartPath,
     '--output', guardPath,
     '--force',
+    '--theme', 'tokyo-night',
   ], { encoding: 'utf8' });
   assert.equal(guardForceResult.status, 0, guardForceResult.stderr);
+  assert.notStrictEqual(
+    readFileSync(guardPath, 'utf8'),
+    guardContentBefore,
+    '--force exited successfully but did not replace the file content',
+  );
+
+  const batchGuardArgs = [
+    join(scriptsDir, 'batch.mjs'),
+    '--input-dir', examplesDir,
+    '--output-dir', join(cliTestDir, 'batch-guard'),
+  ];
+  const batchGuardFirst = spawnSync(process.execPath, batchGuardArgs, { encoding: 'utf8' });
+  assert.equal(batchGuardFirst.status, 0, batchGuardFirst.stderr);
+  const batchGuardRerun = spawnSync(process.execPath, batchGuardArgs, { encoding: 'utf8' });
+  assert.notEqual(batchGuardRerun.status, 0, 'batch.mjs overwrote existing outputs without --force');
+  assert.match(batchGuardRerun.stderr, /already exists/);
+  const batchGuardForce = spawnSync(process.execPath, [...batchGuardArgs, '--force'], { encoding: 'utf8' });
+  assert.equal(batchGuardForce.status, 0, batchGuardForce.stderr);
 } finally {
   rmSync(cliTestDir, { recursive: true, force: true });
 }
 
-console.log(`Smoke tests passed: ${files.length} diagrams x 3 formats, 15 themes, CLI named/custom colors, interactive coverage, overwrite guard.`);
+console.log(`Smoke tests passed: ${files.length} diagrams x 3 formats, 15 themes, CLI named/custom colors, interactive coverage, overwrite guard (single + batch).`);

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -230,8 +230,39 @@ try {
   for (const colorCode of customColorCodes) {
     assert.ok(batchCustomAscii.includes(colorCode), `batch.mjs omitted custom ASCII color ${colorCode}`);
   }
+  const guardPath = join(cliTestDir, 'overwrite-guard.svg');
+  const guardFirstRender = spawnSync(process.execPath, [
+    join(scriptsDir, 'render.mjs'),
+    '--input', flowchartPath,
+    '--output', guardPath,
+  ], { encoding: 'utf8' });
+  assert.equal(guardFirstRender.status, 0, guardFirstRender.stderr);
+
+  const guardRerunResult = spawnSync(process.execPath, [
+    join(scriptsDir, 'render.mjs'),
+    '--input', flowchartPath,
+    '--output', guardPath,
+  ], { encoding: 'utf8' });
+  assert.notEqual(guardRerunResult.status, 0, 'render.mjs overwrote an existing output without --force');
+  assert.match(guardRerunResult.stderr, /already exists/);
+
+  const guardSourceResult = spawnSync(process.execPath, [
+    join(scriptsDir, 'render.mjs'),
+    '--input', flowchartPath,
+    '--output', flowchartPath,
+  ], { encoding: 'utf8' });
+  assert.notEqual(guardSourceResult.status, 0, 'render.mjs overwrote the input file without --force');
+  assert.match(guardSourceResult.stderr, /already exists/);
+
+  const guardForceResult = spawnSync(process.execPath, [
+    join(scriptsDir, 'render.mjs'),
+    '--input', flowchartPath,
+    '--output', guardPath,
+    '--force',
+  ], { encoding: 'utf8' });
+  assert.equal(guardForceResult.status, 0, guardForceResult.stderr);
 } finally {
   rmSync(cliTestDir, { recursive: true, force: true });
 }
 
-console.log(`Smoke tests passed: ${files.length} diagrams x 3 formats, 15 themes, CLI named/custom colors and interactive coverage.`);
+console.log(`Smoke tests passed: ${files.length} diagrams x 3 formats, 15 themes, CLI named/custom colors, interactive coverage, overwrite guard.`);


### PR DESCRIPTION
Closes #10

## Summary

- `scripts/render.mjs`: when `--output` is omitted, every format now writes to a default path next to the source (`<input>.svg` / `<input>.txt` / `<input>.png`) via a shared `defaultOutputPath()` helper, so rendered content never goes to stdout. PNG keeps its existing default; SVG and ASCII now match it. The previously inline PNG-only path logic is folded into the helper.
- `SKILL.md`: adds an "Output discipline" section — pass `--output` deliberately, probe output files with `wc -c` / `head -c` instead of `cat`, and leave visual inspection to the user by handing back the path. Workflow step 6 and the Validation section are reworded to match the new default.

## Test plan

- [x] `npm test` — smoke tests pass (6 diagrams × 3 formats, 15 themes, CLI named/custom colors, interactive coverage)
- [x] `npm run validate` — documentation valid (14 Markdown files, 213 Skill lines, 15 theme previews)
- [x] `node scripts/render.mjs -i diagram.mmd -f svg` (no `--output`) writes `diagram.svg` beside the source, prints only the saved path; same for `-f ascii` → `diagram.txt`; SVG output starts with `<svg`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Rendering now saves SVG, PNG, and ASCII results to files instead of printing rendered content to standard output.
  - Output filenames are generated automatically when no destination is specified.
  - Added `--force` to replace existing output files during single and batch rendering.

- **Bug Fixes**
  - Rendering refuses to overwrite existing files by default, including when the output path matches the input file.

- **Documentation**
  - Clarified output paths, overwrite behavior, syntax references, retry limits, and default theme selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->